### PR TITLE
Added missing network-manager packages for openvpn functionality via gui

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,8 @@ generic_packages:
   - lvm2
   - lynx
   - ncdu
+  - network-manager-openvpn
+  - network-manager-openvpn-gnome
   - ngrep
   - nmap
   - ntp


### PR DESCRIPTION
## Description
Added packages:
network-manager-openvpn
network-manager-openvpn-gnome
to defaults/main.yml 's generic_packages list

## Motivation and Context
These packages are required to allow users to use openvpn via the network manager gui interface

## How Has This Been Tested?
After installing the new image / running the new ansible playbooks, these packages were required to be installed manually to allow users to connect to the VPN in the user space