### PR TITLE
USB Image Creation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,8 @@
   command: /usr/bin/rkhunter --update
   notify: rkhunter propupd
   ignore_errors: true
+  tags: usb
 
 - name: rkhunter propupd
   command: /usr/bin/rkhunter --propupd
+  tags: usb

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ dependencies:
   - name: clamav
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
     version: 9c33996881d1751b6d494f316308f541bf13acfa
+    tags: usb
   - name: fstab
     src: git+https://github.com/UKHomeOffice/ansible-role-fstab
     version: f3929ec6198cd0ca4f84f783ea18705cab5b1e30

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ dependencies:
     version: 30cba0a8ada7a4cb844276c33a88a4af4bd199b1
   - name: clamav
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
-    version: 9c33996881d1751b6d494f316308f541bf13acfa
+    version: fbaaf3067ad3541d1a0afe24f6961e23f7be2f36
     tags: usb
   - name: fstab
     src: git+https://github.com/UKHomeOffice/ansible-role-fstab

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,13 +18,13 @@ dependencies:
     version: d47e0ed05e35c16216644fb85cc74faad320e866
   - name: grub-cmdline
     src: git+https://github.com/UKHomeOffice/ansible-role-grub-cmdline
-    version: 00b8874bd5131a4eee3b30da1fdb028445607e07
+    version: 30cba0a8ada7a4cb844276c33a88a4af4bd199b1
   - name: clamav
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
     version: 62492183628284c3010e3379c97c76369694bb32
   - name: fstab
     src: git+https://github.com/UKHomeOffice/ansible-role-fstab
-    version: c1157ba82915a8937107db6d9ba3ae216ae3cf6d
+    version: f3929ec6198cd0ca4f84f783ea18705cab5b1e30
   - name: openjdk
     src: git+https://github.com/UKHomeOffice/ansible-role-openjdk
     version: 77f1586fc26633afef1a5ba6bb236e39d4f1f4e1

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
     version: 8a0cbe2f886a58e520ea753f26f9f7e2cbb6c645
   - name: audit-hardening
     src:  git+https://github.com/UKHomeOffice/ansible-role-audit-hardening
-    version: 715f3fac1bb9a696105830f6f9d47da09d572c31
+    version: 448b1cb4daee97c1402bcfe15e4bdda7e8a83dab
   - name: os-hardening
     src: git+https://github.com/UKHomeOffice/ansible-role-os-hardening
     version: 9d2bacc1a406eaa695e319f0d494f4ab9edaac2b
@@ -15,7 +15,7 @@ dependencies:
     version: 94230c3d773b9812c41f871829a8180d96dde510
   - name: iptables
     src: git+https://github.com/UKHomeOffice/ansible-role-firewall
-    version: 19f7754b90db7b4018ae63d8fbbec48934bcb818
+    version: d47e0ed05e35c16216644fb85cc74faad320e866
   - name: grub-cmdline
     src: git+https://github.com/UKHomeOffice/ansible-role-grub-cmdline
     version: 00b8874bd5131a4eee3b30da1fdb028445607e07

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ dependencies:
     version: 30cba0a8ada7a4cb844276c33a88a4af4bd199b1
   - name: clamav
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
-    version: 62492183628284c3010e3379c97c76369694bb32
+    version: 9c33996881d1751b6d494f316308f541bf13acfa
   - name: fstab
     src: git+https://github.com/UKHomeOffice/ansible-role-fstab
     version: f3929ec6198cd0ca4f84f783ea18705cab5b1e30
@@ -30,7 +30,7 @@ dependencies:
     version: 77f1586fc26633afef1a5ba6bb236e39d4f1f4e1
   - name: docker
     src: git+https://github.com/UKHomeOffice/ansible-role-docker
-    version: ad88be969fdf9f58fb3fbd4a2ed9b42c7d9c6036
+    version: 2f9c3b930d4526f304f3c64d6d48230df32284da
   - name: sysdig
     src: git+https://github.com/UKHomeOffice/ansible-sysdig
     version: 88f8620e800458fbab853bab3104a8662c26f98a

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
     version: 8a0cbe2f886a58e520ea753f26f9f7e2cbb6c645
   - name: audit-hardening
     src:  git+https://github.com/UKHomeOffice/ansible-role-audit-hardening
-    version: 285a065692a3e294ee90a08eab1a8e92e417df32
+    version: 715f3fac1bb9a696105830f6f9d47da09d572c31
   - name: os-hardening
     src: git+https://github.com/UKHomeOffice/ansible-role-os-hardening
     version: 9d2bacc1a406eaa695e319f0d494f4ab9edaac2b

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ dependencies:
     version: 9d2bacc1a406eaa695e319f0d494f4ab9edaac2b
   - name: ssh-hardening
     src: git+https://github.com/UKHomeOffice/ansible-role-ssh-hardening
-    version: 94230c3d773b9812c41f871829a8180d96dde510
+    version: 0450ce0c42049b9d4f2850a9982609cde25a24f9
   - name: iptables
     src: git+https://github.com/UKHomeOffice/ansible-role-firewall
     version: d47e0ed05e35c16216644fb85cc74faad320e866

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: https://github.com/UKHomeOffice/ansible-base-role.git
-  version: master
+  version: service
   name: generic
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -26,6 +26,14 @@
   with_items:
     - "{{ os_packages }}"
 
+- name: Install Generic Packages - Debian when not on usb
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - "{{ os_packages_notusb }}"
+  tags: usb
+
 - name: Remove Banned Packages
   apt:
     name: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
     state: started
     enabled: True
   when: (ansible_distribution_version >= '7' or ansible_os_family == 'Debian') 
+  tags: usb
 
 - name: force gpg2
   file:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -35,10 +35,12 @@ os_packages:
   - virtualenv
   - whois
   - yubikey-luks
-  - yubikey-ksm
   - yubico-piv-tool
   - vim-scripts
   - zlib1g-dev
+
+os_packages_notusb:
+  - yubikey-ksm
 
 os_banned_packages:
   - gnome-mines

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -32,3 +32,5 @@ os_packages_conflicting_remove:
   - nfs-utils
 
 os_banned_packages:
+
+os_packages_notusb:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -31,3 +31,5 @@ os_packages_conflicting_remove:
   - nfs-utils
 
 os_banned_packages:
+
+os_packages_notusb:


### PR DESCRIPTION
This update allows for roles to be installed during the USB Image creation, some roles needed updates to not restart services as this is not allowed whilst building the image.

Ideally this role would be triggered again at the end of a physical install by the USB key