### PR TITLE
50unattended-upgrades: Corrected typo stopping automatic upgrades

### DIFF
--- a/files/50unattended-upgrades
+++ b/files/50unattended-upgrades
@@ -1,4 +1,3 @@
-/etc/apt/apt.conf.d/50unattended-upgrades 
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
 	"${distro_id}:${distro_codename}-security";

--- a/files/50unattended-upgrades
+++ b/files/50unattended-upgrades
@@ -1,9 +1,9 @@
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
 	"${distro_id}:${distro_codename}-security";
-	"${distro_id}:${distro_codename}-updates";
-	"${distro_id}:${distro_codename}-proposed";
-	"${distro_id}:${distro_codename}-backports";
+//	"${distro_id}:${distro_codename}-updates";
+//	"${distro_id}:${distro_codename}-proposed";
+//	"${distro_id}:${distro_codename}-backports";
 };
 
 // List of packages to not update (regexp are supported)


### PR DESCRIPTION
## Description
50unattended-upgrades had a syntax error stopping the accepted origins from being read - since there were no accepted origins / repos, unattended upgrades didn't occur.

## Motivation and Context
JIRA ticket CROSSING-7072

## How Has This Been Tested?
Checking logs before / after change (/var/log/unattendedupgrades)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

