### PR TITLE
meta/main.yml: Removed fstab role from dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,9 +23,6 @@ dependencies:
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
     version: fbaaf3067ad3541d1a0afe24f6961e23f7be2f36
     tags: usb
-  - name: fstab
-    src: git+https://github.com/UKHomeOffice/ansible-role-fstab
-    version: f3929ec6198cd0ca4f84f783ea18705cab5b1e30
   - name: openjdk
     src: git+https://github.com/UKHomeOffice/ansible-role-openjdk
     version: 77f1586fc26633afef1a5ba6bb236e39d4f1f4e1

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,6 +7,8 @@ os_packages:
   - dnsutils
   - git-crypt
   - gnupg-pkcs11-scd
+  - gnupg
+  - gnupg2
   - iwatch
   - iptables-persistent
   - kernel-package


### PR DESCRIPTION
## Description
Removed fstab role from dependencies

## Motivation and Context
This role creates a new fstab on systems it is used on, this should not be defined here - if people have different file systems set up it will break their systems / this should be defined at the system installation stage not here.
This will block testing the full ansible playbook on vms etc.

## How Has This Been Tested?
Tested full playbook against a vagrant VM, this causes various things to fail as vagrant boxes do not have the same fs setup as we do internally.
