### PR TITLE
CROSSING-7336

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ dependencies:
     version: 30cba0a8ada7a4cb844276c33a88a4af4bd199b1
   - name: clamav
     src: git+https://github.com/UKHomeOffice/ansible-role-clamav
-    version: fbaaf3067ad3541d1a0afe24f6961e23f7be2f36
+    version: d930c6ac08a71176989f09258bd2b5d9f0d8166b
     tags: usb
   - name: fstab
     src: git+https://github.com/UKHomeOffice/ansible-role-fstab


### PR DESCRIPTION
fix (EUD): latest changes in clamav have to be incorporated into EUD builds.

See "https://github.com/UKHomeOffice/ansible-role-clamav/pull/9" for changes in clamav